### PR TITLE
Added support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,14 @@
         "ext-json": "*",
         "bacon/bacon-qr-code": "^2.0",
         "paragonie/constant_time_encoding": "^2.0",
-        "illuminate/support": "^6.15||^7.0",
-        "illuminate/auth": "^6.15||^7.0"
+        "illuminate/support": "^6.15||^7.0||^8.0",
+        "illuminate/auth": "^6.15||^7.0||^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0||^5.0",
-        "orchestra/canvas": "^4.0||^5.0",
-        "phpunit/phpunit": "^8.0"
+        "orchestra/testbench": "^4.0||^5.0||^6.0",
+        "orchestra/canvas": "^4.0||^5.0||^6.0",
+        "laravel/legacy-factories": "^1.0",
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.15",
+        "php": "^7.2.15||^7.3.0",
         "ext-json": "*",
         "bacon/bacon-qr-code": "^2.0",
         "paragonie/constant_time_encoding": "^2.0",
@@ -31,8 +31,6 @@
     "require-dev": {
         "orchestra/testbench": "^4.0||^5.0||^6.0",
         "orchestra/canvas": "^4.0||^5.0||^6.0",
-        "laravel/legacy-factories": "^1.0",
-        "illuminate/macroable": "^8.0",
         "phpunit/phpunit": "^8.0||^9.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "orchestra/testbench": "^4.0||^5.0||^6.0",
         "orchestra/canvas": "^4.0||^5.0||^6.0",
         "laravel/legacy-factories": "^1.0",
+        "illuminate/macroable": "^8.0",
         "phpunit/phpunit": "^8.0||^9.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "orchestra/testbench": "^4.0||^5.0||^6.0",
         "orchestra/canvas": "^4.0||^5.0||^6.0",
         "laravel/legacy-factories": "^1.0",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^8.0||^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I added the required dependencies for Laravel 8 into the composer.json.

I also run all unit tests against Laravel 8 framework and all has been passed (By the way did you notice how fast the test are executed in comparison with PHPUnit 8.x?)

```
PHPUnit 9.3.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.8 with Xdebug 2.9.1
Configuration: /X/Projects/tmp/Laraguard/phpunit.xml.dist
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

................................................................. 65 / 96 ( 67%)
...............................                                   96 / 96 (100%)

Time: 00:22.984, Memory: 42.00 MB

OK (96 tests, 411 assertions)
```

I had to add "laravel/legacy-factories" in order to maintain the factories compatible with Laravel 8 and I also upgraded PHPUnit.